### PR TITLE
Return correct type in Awaitable returns.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,8 +132,6 @@ select = [
 ]
 ignore = [
     "A001",  # Variable is shadowing a Python builtin
-    "ANN101",  # Missing type annotation for self
-    "ANN102",  # Missing type annotation for cls
     "ANN204",  # Missing return type annotation for special method __str__
     "ANN401",  # Dynamically typed expressions (typing.Any) are disallowed
     "ARG005",  # Unused lambda argument

--- a/src/dependency_container/__init__.py
+++ b/src/dependency_container/__init__.py
@@ -7,4 +7,4 @@ from dependency_container.container import DependencyContainer
 from dependency_container.fastapi import InjectableRouter
 
 __all__: list[str] = ["DependencyContainer", "InjectableRouter"]
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/src/dependency_container/container.py
+++ b/src/dependency_container/container.py
@@ -5,7 +5,7 @@ Factory for FastApi routers that inject delayed dependants into actual dependant
 
 import sys
 from abc import ABCMeta
-from collections.abc import Callable, Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from inspect import Parameter, Signature, signature
@@ -46,7 +46,10 @@ class _DelayedDependant:
 def _get_dependent_source(dependent_origin: type | None) -> type:
     """Get the source type of a dependent."""
     if isinstance(dependent_origin, Callable):
-        return get_args(dependent_origin)[1]
+        source = get_args(dependent_origin)[1]
+        if getattr(source, "__origin__", None) == Awaitable:
+            return get_args(source)[0]
+        return source
     if dependent_origin is None:
         raise TypeError(f"Dependant origin {dependent_origin} is not a valid type.")
 

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,6 +1,6 @@
 """Test for the redis injector."""
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import Annotated, Final
 
 import pytest
@@ -11,10 +11,10 @@ from dependency_container.faststream.redis import InjectableRedisRouter
 
 
 class _MyContainer(DependencyContainer):
-    x: Callable[..., int]
+    x: Callable[..., Awaitable[int]]
 
 
-def _my_dependency() -> int:
+async def _my_dependency() -> int:
     return 5
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -208,7 +208,7 @@ toml = [
 
 [[package]]
 name = "dependency-container"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Checks if the return type of a dependency is an `Awaitable[T]`, and will return just `T`